### PR TITLE
Fix test classpath escaping issue

### DIFF
--- a/gatling-maven-plugin/src/main/java/io/gatling/mojo/GatlingMojo.java
+++ b/gatling-maven-plugin/src/main/java/io/gatling/mojo/GatlingMojo.java
@@ -35,6 +35,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -409,14 +410,9 @@ public class GatlingMojo extends AbstractGatlingMojo {
 
     URL[] urls = new URL[testClasspathElements.size()];
     for (int i = 0; i < testClasspathElements.size(); i++) {
-
-      String url = "file:" + testClasspathElements.get(i);
-      if (!url.endsWith(".jar")) {
-        // directory, has to end with a /
-        url += "/";
-      }
-
-      urls[i] = new URL(url);
+      String testClasspathElement = testClasspathElements.get(i);
+      URL url = Paths.get(testClasspathElement).toUri().toURL();
+      urls[i] = url;
     }
 
     return urls;


### PR DESCRIPTION
Gatling Maven plugin fails to startup if there's URL special char like '%' in the path with `ClassNotFoundException`:

```
[ERROR] Failed to execute goal io.gatling:gatling-maven-plugin:2.2.0:execute (default-cli) on project uhs-wrapper-performance: Gatling failed. java.lang.ClassNotFoundException: simulations.UhsWrapperSimulation$$anonfun$initSession$1$$anonfun$1 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal io.gatling:gatling-maven-plugin:2.2.0:execute (default-cli) on project uhs-wrapper-performance: Gatling failed.
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:39)
	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:122)
	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:50)
Caused by: org.apache.maven.plugin.MojoExecutionException: Gatling failed.
	at io.gatling.mojo.GatlingMojo.execute(GatlingMojo.java:213)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 27 more
Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: simulations.UhsWrapperSimulation$$anonfun$initSession$1$$anonfun$1
	at io.gatling.mojo.GatlingMojo.resolveSimulations(GatlingMojo.java:402)
	at io.gatling.mojo.GatlingMojo.simulations(GatlingMojo.java:322)
	at io.gatling.mojo.GatlingMojo.execute(GatlingMojo.java:205)
	... 29 more
Caused by: java.lang.ClassNotFoundException: simulations.UhsWrapperSimulation$$anonfun$initSession$1$$anonfun$1
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at io.gatling.mojo.GatlingMojo.resolveSimulations(GatlingMojo.java:392)
	... 31 more
```

This is caused by direct path to URL transformation. This change replaces path to URL transformation code with a call to `Path.toUri()` that handles escaping of special characters and appends '/' if path
refers to a directory.